### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_dnsmadeeasy.py
+++ b/tests/test_octodns_provider_dnsmadeeasy.py
@@ -118,7 +118,9 @@ class TestDnsMadeEasyProvider(TestCase):
 
     def test_apply(self):
         # Create provider with sandbox enabled
-        provider = DnsMadeEasyProvider('test', 'api', 'secret', True)
+        provider = DnsMadeEasyProvider(
+            'test', 'api', 'secret', True, strict_supports=False
+        )
 
         resp = Mock()
         resp.json = Mock()


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957