### PR TITLE
Mark that we support root NS records

### DIFF
--- a/octodns_dnsmadeeasy/__init__.py
+++ b/octodns_dnsmadeeasy/__init__.py
@@ -140,6 +140,7 @@ class DnsMadeEasyClient(object):
 class DnsMadeEasyProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_ROOT_NS = True
     SUPPORTS = set(
         (
             'A',


### PR DESCRIPTION
I was trying to create some root NS records, something DNSMADEEASY supports additional NS records for (I do not believe you can modify the "built-in" records), but octodns wasn't creating them because it said they were not supported with this provider. If I manually set this property the additional records can be added/managed the same as normal.