### PR TITLE
v0.0.2 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.2 - 2023-03-29 - Root NS support
+
+* Enable Root NS record support for managing the top-level NS records in zones
+* Add a user-agent to all API requests
+
 ## v0.0.1 - 2022-01-06 - Moving
 
 #### Nothworthy Changes

--- a/octodns_dnsmadeeasy/__init__.py
+++ b/octodns_dnsmadeeasy/__init__.py
@@ -15,7 +15,7 @@ from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class DnsMadeEasyClientException(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2023-03-29 - Root NS support

* Enable Root NS record support for managing the top-level NS records in zones
* Add a user-agent to all API requests

/cc https://github.com/octodns/octodns-dnsmadeeasy/issues/15 @npaufler