### PR TITLE
Update __init__.py

### DIFF
--- a/octodns_dnsmadeeasy/__init__.py
+++ b/octodns_dnsmadeeasy/__init__.py
@@ -102,7 +102,7 @@ class DnsMadeEasyClient(object):
         return self._request('GET', path).json()
 
     def domain_create(self, name):
-        self._request('POST', '/', data={'name': name})
+        self._domains[name+"."] = self._request('POST', '/', data={'name': name}).json()['id']
 
     def records(self, zone_name):
         zone_id = self.domains.get(zone_name, False)


### PR DESCRIPTION
Sync failed if the domain didn't exist; domain_create did not add the new domain (name) to the _domains dictionary, so subsequent record additions would fail because of line 108 always returning False (because domain not in dictionary).