### PR TITLE
Add support for bulk record updates, create domain fix

### DIFF
--- a/octodns_dnsmadeeasy/__init__.py
+++ b/octodns_dnsmadeeasy/__init__.py
@@ -133,7 +133,7 @@ class DnsMadeEasyClient(object):
     def record_multi_delete(self, zone_name, record_ids):
         zone_id = self.domains.get(zone_name, False)
         path = f'/{zone_id}/records'
-        self._request('DELETE', path, params={'id': record_ids})
+        self._request('DELETE', path, params={'ids': record_ids})
 
     def record_multi_create(self, zone_name, records):
         zone_id = self.domains.get(zone_name, False)

--- a/octodns_dnsmadeeasy/__init__.py
+++ b/octodns_dnsmadeeasy/__init__.py
@@ -108,6 +108,8 @@ class DnsMadeEasyClient(object):
 
     def records(self, zone_name):
         zone_id = self.domains.get(zone_name, False)
+        if not zone_id:
+            return []
         path = f'/{zone_id}/records'
         ret = []
 
@@ -250,10 +252,7 @@ class DnsMadeEasyProvider(BaseProvider):
 
     def zone_records(self, zone):
         if zone.name not in self._zone_records:
-            try:
-                self._zone_records[zone.name] = self._client.records(zone.name)
-            except DnsMadeEasyClientNotFound:
-                return []
+            self._zone_records[zone.name] = self._client.records(zone.name)
 
         return self._zone_records[zone.name]
 

--- a/tests/fixtures/dnsmadeeasy-domain-create.json
+++ b/tests/fixtures/dnsmadeeasy-domain-create.json
@@ -1,0 +1,38 @@
+{
+  "created": 1520294400000,
+  "folderId": 18954,
+  "gtdEnabled": false,
+  "nameServers": [
+    {
+      "ipv6": "2600:1800:0::1",
+      "ipv4": "208.94.148.2",
+      "fqdn": "ns0.dnsmadeeasy.com"
+    },
+    {
+      "ipv6": "2600:1801:1::1",
+      "ipv4": "208.80.124.2",
+      "fqdn": "ns1.dnsmadeeasy.com"
+    },
+    {
+      "ipv6": "2600:1802:2::1",
+      "ipv4": "208.80.126.2",
+      "fqdn": "ns2.dnsmadeeasy.com"
+    },
+    {
+      "ipv6": "2600:1801:3::1",
+      "ipv4": "208.80.125.2",
+      "fqdn": "ns3.dnsmadeeasy.com"
+    },
+    {
+      "ipv6": "2600:1802:4::1",
+      "ipv4": "208.80.127.2",
+      "fqdn": "ns4.dnsmadeeasy.com"
+    }
+  ],
+  "updated": 1520350904465,
+  "processMulti": false,
+  "activeThirdParties": [],
+  "pendingActionId": 1,
+  "name": "unit.tests",
+  "id": 123123
+}

--- a/tests/fixtures/dnsmadeeasy-no-domains.json
+++ b/tests/fixtures/dnsmadeeasy-no-domains.json
@@ -1,0 +1,6 @@
+{
+	"totalPages": 1,
+	"totalRecords": 0,
+	"data": [],
+	"page": 0
+}

--- a/tests/test_octodns_provider_dnsmadeeasy.py
+++ b/tests/test_octodns_provider_dnsmadeeasy.py
@@ -131,13 +131,18 @@ class TestDnsMadeEasyProvider(TestCase):
         with open('tests/fixtures/dnsmadeeasy-domains.json') as fh:
             domains = json.load(fh)
 
+        with open('tests/fixtures/dnsmadeeasy-domain-create.json') as fh:
+            created_domain = json.load(fh)
+
         # non-existent domain, create everything
         resp.json.side_effect = [
             DnsMadeEasyClientNotFound,  # no zone in populate
             DnsMadeEasyClientNotFound,  # no domain during apply
+            created_domain,  # our created domain response
             domains,
         ]
         plan = provider.plan(self.expected)
+        print(plan)
 
         # No ignored, no excluded, no unsupported
         n = len(self.expected.records) - 9
@@ -150,65 +155,182 @@ class TestDnsMadeEasyProvider(TestCase):
                 call('POST', '/', data={'name': 'unit.tests'}),
                 # get all domains to build the cache
                 call('GET', '/'),
-                # created at least some of the record with expected data
+                # created all the non-existent records in a single request
                 call(
                     'POST',
-                    '/123123/records',
-                    data={
-                        'type': 'A',
-                        'name': '',
-                        'value': '1.2.3.4',
-                        'ttl': 300,
-                    },
-                ),
-                call(
-                    'POST',
-                    '/123123/records',
-                    data={
-                        'type': 'A',
-                        'name': '',
-                        'value': '1.2.3.5',
-                        'ttl': 300,
-                    },
-                ),
-                call(
-                    'POST',
-                    '/123123/records',
-                    data={
-                        'type': 'ANAME',
-                        'name': '',
-                        'value': 'aname.unit.tests.',
-                        'ttl': 1800,
-                    },
-                ),
-                call(
-                    'POST',
-                    '/123123/records',
-                    data={
-                        'name': '',
-                        'value': 'ca.unit.tests',
-                        'issuerCritical': 0,
-                        'caaType': 'issue',
-                        'ttl': 3600,
-                        'type': 'CAA',
-                    },
-                ),
-                call(
-                    'POST',
-                    '/123123/records',
-                    data={
-                        'name': '_srv._tcp',
-                        'weight': 20,
-                        'value': 'foo-1.unit.tests.',
-                        'priority': 10,
-                        'ttl': 600,
-                        'type': 'SRV',
-                        'port': 30,
-                    },
+                    '/123123/records/createMulti',
+                    data=[
+                        {
+                            'value': '1.2.3.4',
+                            'name': '',
+                            'ttl': 300,
+                            'type': 'A',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '1.2.3.5',
+                            'name': '',
+                            'ttl': 300,
+                            'type': 'A',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'aname.unit.tests.',
+                            'name': '',
+                            'ttl': 1800,
+                            'type': 'ANAME',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'ca.unit.tests',
+                            'issuerCritical': 0,
+                            'name': '',
+                            'caaType': 'issue',
+                            'ttl': 3600,
+                            'type': 'CAA',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'foo-1.unit.tests.',
+                            'name': '_srv._tcp',
+                            'port': 30,
+                            'priority': 10,
+                            'ttl': 600,
+                            'type': 'SRV',
+                            'weight': 20,
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'foo-2.unit.tests.',
+                            'name': '_srv._tcp',
+                            'port': 30,
+                            'priority': 12,
+                            'ttl': 600,
+                            'type': 'SRV',
+                            'weight': 20,
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '2601:644:500:e210:62f8:1dff:feb8:947a',
+                            'name': 'aaaa',
+                            'ttl': 600,
+                            'type': 'AAAA',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'unit.tests.',
+                            'name': 'cname',
+                            'ttl': 300,
+                            'type': 'CNAME',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'unit.tests.',
+                            'name': 'included',
+                            'ttl': 3600,
+                            'type': 'CNAME',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'smtp-4.unit.tests.',
+                            'name': 'mx',
+                            'mxLevel': 10,
+                            'ttl': 300,
+                            'type': 'MX',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'smtp-2.unit.tests.',
+                            'name': 'mx',
+                            'mxLevel': 20,
+                            'ttl': 300,
+                            'type': 'MX',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'smtp-3.unit.tests.',
+                            'name': 'mx',
+                            'mxLevel': 30,
+                            'ttl': 300,
+                            'type': 'MX',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'smtp-1.unit.tests.',
+                            'name': 'mx',
+                            'mxLevel': 40,
+                            'ttl': 300,
+                            'type': 'MX',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'foo.bar.com.',
+                            'name': 'ptr',
+                            'ttl': 300,
+                            'type': 'PTR',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '"v=spf1 ip4:192.168.0.1/16-all"',
+                            'name': 'spf',
+                            'ttl': 600,
+                            'type': 'SPF',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '"Bah bah black sheep"',
+                            'name': 'txt',
+                            'ttl': 600,
+                            'type': 'TXT',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '"have you any wool."',
+                            'name': 'txt',
+                            'ttl': 600,
+                            'type': 'TXT',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '"v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs"',
+                            'name': 'txt',
+                            'ttl': 600,
+                            'type': 'TXT',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'ns1.unit.tests.',
+                            'name': 'under',
+                            'ttl': 3600,
+                            'type': 'NS',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': 'ns2.unit.tests.',
+                            'name': 'under',
+                            'ttl': 3600,
+                            'type': 'NS',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '2.2.3.6',
+                            'name': 'www',
+                            'ttl': 300,
+                            'type': 'A',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '2.2.3.6',
+                            'name': 'www.sub',
+                            'ttl': 300,
+                            'type': 'A',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                    ],
                 ),
             ]
         )
-        self.assertEqual(26, provider._client._request.call_count)
+        self.assertEqual(5, provider._client._request.call_count)
 
         provider._client._request.reset_mock()
 
@@ -258,17 +380,54 @@ class TestDnsMadeEasyProvider(TestCase):
             [
                 call(
                     'POST',
-                    '/123123/records',
-                    data={
-                        'value': '3.2.3.4',
-                        'type': 'A',
-                        'name': 'ttl',
-                        'ttl': 300,
-                    },
+                    '/123123/records/createMulti',
+                    data=[
+                        {
+                            'value': '3.2.3.4',
+                            'type': 'A',
+                            'name': 'ttl',
+                            'ttl': 300,
+                            'gtdLocation': 'DEFAULT',
+                        }
+                    ],
                 ),
-                call('DELETE', '/123123/records/11189899'),
-                call('DELETE', '/123123/records/11189897'),
-                call('DELETE', '/123123/records/11189898'),
+                call(
+                    'DELETE',
+                    '/123123/records',
+                    params={'id': [11189897, 11189898, 11189899]},
+                ),
             ],
             any_order=True,
         )
+        self.assertEqual(3, provider._client._request.call_count)
+
+        # test for just deleting a record, no additions
+
+        provider._client._request.reset_mock()
+        provider._client.records = Mock(
+            return_value=[
+                {
+                    'id': 11189897,
+                    'name': 'www',
+                    'value': '1.2.3.4',
+                    'ttl': 300,
+                    'type': 'A',
+                }
+            ]
+        )
+
+        # Domain exists, we don't care about return
+        resp.json.side_effect = ['{}']
+
+        wanted = Zone('unit.tests.', [])
+
+        plan = provider.plan(wanted)
+        self.assertEqual(1, len(plan.changes))
+        self.assertEqual(1, provider.apply(plan))
+
+        # recreate for update, and deletes for the 2 parts of the other
+        provider._client._request.assert_has_calls(
+            [call('DELETE', '/123123/records', params={'id': [11189897]})],
+            any_order=True,
+        )
+        self.assertEqual(2, provider._client._request.call_count)

--- a/tests/test_octodns_provider_dnsmadeeasy.py
+++ b/tests/test_octodns_provider_dnsmadeeasy.py
@@ -394,7 +394,7 @@ class TestDnsMadeEasyProvider(TestCase):
                 call(
                     'DELETE',
                     '/123123/records',
-                    params={'id': [11189897, 11189898, 11189899]},
+                    params={'ids': [11189897, 11189898, 11189899]},
                 ),
             ],
             any_order=True,
@@ -427,7 +427,7 @@ class TestDnsMadeEasyProvider(TestCase):
 
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls(
-            [call('DELETE', '/123123/records', params={'id': [11189897]})],
+            [call('DELETE', '/123123/records', params={'ids': [11189897]})],
             any_order=True,
         )
         self.assertEqual(2, provider._client._request.call_count)


### PR DESCRIPTION
Based on the work in PR #18 and PR #19, this makes the following changes:

1. Add newly created domains to the cache so records can be created immediately.
2. Use bulk record creation/deletion endpoints on the DNS Made Easy API to reduce the number of API calls that need to be made to update records.

I have updated the tests to cover this and there is 100% test coverage.