### PR TITLE
Fix issues with long TXT records

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Pinning specific versions or SHAs is recommended to avoid unplanned upgrades.
 
 ```
 # Start with the latest versions and don't just copy what's here
-octodns==0.9.14
-octodns-dnsmadeeasy==0.0.1
+octodns==1.0.0
+octodns-dnsmadeeasy==0.0.4
 ```
 
 ##### SHAs

--- a/octodns_dnsmadeeasy/__init__.py
+++ b/octodns_dnsmadeeasy/__init__.py
@@ -245,10 +245,8 @@ class DnsMadeEasyProvider(BaseProvider):
     def _data_for_TXT(self, _type, records):
         # Long TXT records in DNS Mady Easy have their value split into 255 character chunks, delimited by "".
         values = [
-            re.sub(
-                self.TXT_RECORD_VALUE_DELIMITER_PATTERN,
-                '',
-                value['value'].replace(';', '\\;'),
+            self.TXT_RECORD_VALUE_DELIMITER_PATTERN.sub(
+                '', value['value'].replace(';', '\\;')
             )
             for value in records
         ]

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -149,10 +149,18 @@ ptr:
   ttl: 300
   type: PTR
   values: [foo.bar.com.]
+quotes:
+  ttl: 600
+  type: TXT
+  value: This is a TXT record with \"quotes\" in it to ensure they are handled correctly
 spf:
   ttl: 600
   type: SPF
   value: v=spf1 ip4:192.168.0.1/16-all
+split:
+  ttl: 600
+  type: TXT
+  value: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc porttitor, odio eleifend ullamcorper ultricies, lectus lorem iaculis erat, ut porttitor erat orci eget est. Nunc tortor odio, suscipit non maximus in, euismod nec dolor. Nullam quis ultricies orci. Donec malesuada tempor accumsan. Vivamus erat eros, condimentum et urna vitae, aliquam congue quam. Phasellus nibh mauris, congue quis euismod vel, porta sed dui. Fusce massa dui, feugiat dapibus condimentum nec, vulputate eget ex. Sed vitae augue et ex facilisis placerat id sit amet tortor. Morbi pellentesque velit arcu, ut suscipit quam consectetur in. Quisque pulvinar ante sit amet egestas gravida. Etiam accumsan urna et suscipit pulvinar. Fusce ultricies congue sapien non semper. Morbi eleifend molestie blandit. Suspendisse potenti. Fusce vestibulum commodo leo. Nulla cursus turpis sit amet tincidunt bibendum.
 sub:
   type: 'NS'
   values:

--- a/tests/fixtures/dnsmadeeasy-records.json
+++ b/tests/fixtures/dnsmadeeasy-records.json
@@ -339,6 +339,34 @@
     "redirectType": "Standard - 302",
     "description": "unsupported record",
     "type": "HTTPRED"
+  }, {
+    "failover": false,
+    "monitor": false,
+    "sourceId": 123123,
+    "dynamicDns": false,
+    "failed": false,
+    "gtdLocation": "DEFAULT",
+    "hardLink": false,
+    "ttl": 600,
+    "source": 1,
+    "name": "quotes",
+    "value": "\"This is a TXT record with \\\"quotes\\\" in it to ensure they are handled correctly\"",
+    "id": 11189900,
+    "type": "TXT"
+  }, {
+    "failover": false,
+    "monitor": false,
+    "sourceId": 123123,
+    "dynamicDns": false,
+    "failed": false,
+    "gtdLocation": "DEFAULT",
+    "hardLink": false,
+    "ttl": 600,
+    "source": 1,
+    "name": "split",
+    "value": "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc porttitor, odio eleifend ullamcorper ultricies, lectus lorem iaculis erat, ut porttitor erat orci eget est. Nunc tortor odio, suscipit non maximus in, euismod nec dolor. Nullam quis ultricies \"\"orci. Donec malesuada tempor accumsan. Vivamus erat eros, condimentum et urna vitae, aliquam congue quam. Phasellus nibh mauris, congue quis euismod vel, porta sed dui. Fusce massa dui, feugiat dapibus condimentum nec, vulputate eget ex. Sed vitae augue \"\"et ex facilisis placerat id sit amet tortor. Morbi pellentesque velit arcu, ut suscipit quam consectetur in. Quisque pulvinar ante sit amet egestas gravida. Etiam accumsan urna et suscipit pulvinar. Fusce ultricies congue sapien non semper. Morbi eleifen\"\"d molestie blandit. Suspendisse potenti. Fusce vestibulum commodo leo. Nulla cursus turpis sit amet tincidunt bibendum.\"",
+    "id": 11189901,
+    "type": "TXT"
   }],
 	"page": 0
 }

--- a/tests/test_octodns_provider_dnsmadeeasy.py
+++ b/tests/test_octodns_provider_dnsmadeeasy.py
@@ -103,14 +103,14 @@ class TestDnsMadeEasyProvider(TestCase):
 
                 zone = Zone('unit.tests.', [])
                 provider.populate(zone)
-                self.assertEqual(14, len(zone.records))
+                self.assertEqual(16, len(zone.records))
                 changes = self.expected.changes(zone, provider)
                 self.assertEqual(0, len(changes))
 
         # 2nd populate makes no network calls/all from cache
         again = Zone('unit.tests.', [])
         provider.populate(again)
-        self.assertEqual(14, len(again.records))
+        self.assertEqual(16, len(again.records))
 
         # bust the cache
         del provider._zone_records[zone.name]
@@ -284,10 +284,24 @@ class TestDnsMadeEasyProvider(TestCase):
                             'gtdLocation': 'DEFAULT',
                         },
                         {
+                            'value': '"This is a TXT record with \\"quotes\\" in it to ensure they are handled correctly"',
+                            'name': 'quotes',
+                            'ttl': 600,
+                            'type': 'TXT',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
                             'value': '"v=spf1 ip4:192.168.0.1/16-all"',
                             'name': 'spf',
                             'ttl': 600,
                             'type': 'SPF',
+                            'gtdLocation': 'DEFAULT',
+                        },
+                        {
+                            'value': '"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc porttitor, odio eleifend ullamcorper ultricies, lectus lorem iaculis erat, ut porttitor erat orci eget est. Nunc tortor odio, suscipit non maximus in, euismod nec dolor. Nullam quis ultricies orci. Donec malesuada tempor accumsan. Vivamus erat eros, condimentum et urna vitae, aliquam congue quam. Phasellus nibh mauris, congue quis euismod vel, porta sed dui. Fusce massa dui, feugiat dapibus condimentum nec, vulputate eget ex. Sed vitae augue et ex facilisis placerat id sit amet tortor. Morbi pellentesque velit arcu, ut suscipit quam consectetur in. Quisque pulvinar ante sit amet egestas gravida. Etiam accumsan urna et suscipit pulvinar. Fusce ultricies congue sapien non semper. Morbi eleifend molestie blandit. Suspendisse potenti. Fusce vestibulum commodo leo. Nulla cursus turpis sit amet tincidunt bibendum."',
+                            'name': 'split',
+                            'ttl': 600,
+                            'type': 'TXT',
                             'gtdLocation': 'DEFAULT',
                         },
                         {


### PR DESCRIPTION
We spotted a couple of issues with long TXT records:

 - DME API wasn't handling the chunked records correctly on updates as it expects the records to be non-chunked, I have modified the module to use the non-chunked values.
 - DME API presented long records delimited by `""` and this wasn't being handled correctly in the module.
 
 The end result of these issues was that long TXT records were always being considered as a change, even if they hadn't been changed.
 
 I have updated the automated tests and there is 100% coverage.