### PR TITLE
Version 1.0.1 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/34b697a302594d8f80ce45816e0b0537.md
+++ b/.changelog/34b697a302594d8f80ce45816e0b0537.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/4c1e71d7e7a34073a90caad74c72ef01.md
+++ b/.changelog/4c1e71d7e7a34073a90caad74c72ef01.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/625305c00d9a46f19052669f8916297b.md
+++ b/.changelog/625305c00d9a46f19052669f8916297b.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/7766908907544c0b94e74a7bed21b16b.md
+++ b/.changelog/7766908907544c0b94e74a7bed21b16b.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/7d9e91ecf5ef4cb9a12b2f5040a1eb9a.md
+++ b/.changelog/7d9e91ecf5ef4cb9a12b2f5040a1eb9a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/917ef094d8594dec828de6414bf6e261.md
+++ b/.changelog/917ef094d8594dec828de6414bf6e261.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/96cce903d363466b9b2c9727f8a55071.md
+++ b/.changelog/96cce903d363466b9b2c9727f8a55071.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/a95229833c354259b56899dce8621ac4.md
+++ b/.changelog/a95229833c354259b56899dce8621ac4.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 - 2026-04-03
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#55](https://github.com/octodns/octodns-dnsmadeeasy/pull/55)
+
 ## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 Noteworthy Changes:

--- a/octodns_dnsmadeeasy/__init__.py
+++ b/octodns_dnsmadeeasy/__init__.py
@@ -17,7 +17,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 
 class DnsMadeEasyClientException(ProviderException):


### PR DESCRIPTION
## 1.0.1 - 2026-04-03

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#55](https://github.com/octodns/octodns-dnsmadeeasy/pull/55)

