### PR TITLE
Fix script/ tooling to work correctly in git worktrees

### DIFF
--- a/.changelog/abddc5d82f3f4a52b28c6236e8eff96b.md
+++ b/.changelog/abddc5d82f3f4a52b28c6236e8eff96b.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Fix script/ tooling to work correctly in git worktrees

--- a/.git_hooks_pre-commit
+++ b/.git_hooks_pre-commit
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Scripts path
-SCRIPT_PATH="$( dirname -- "$( readlink -f -- "${0}"; )"; )/script"
+# Scripts path -- resolve the worktree being committed, not the checkout this
+# hook symlink happens to live in (see `git worktree`)
+SCRIPT_PATH="$( git rev-parse --show-toplevel; )/script"
 # Activate OctoDNS Python venv
 source "${SCRIPT_PATH}/common.sh"
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,7 +4,7 @@
 
 set -e
 
-cd "$(dirname "$0")"/..
+cd "$(dirname -- "$(readlink -f -- "$0")")"/..
 ROOT=$(pwd)
 
 if [ -z "$VENV_NAME" ]; then
@@ -25,16 +25,26 @@ fi
 python -m pip install -U 'pip>=10.0.1'
 python -m pip install -r requirements.txt
 
-if [ -d ".git" ]; then
+# Use git itself, rather than testing for a ".git" directory, so this works
+# from a linked `git worktree` too (there ".git" is a file, not a directory).
+if git rev-parse --git-dir >/dev/null 2>&1; then
     if [ -f ".git-blame-ignore-revs" ]; then
         echo ""
         echo "Setting blame.ignoreRevsFile to .git-blame-ingore-revs"
         git config --local blame.ignoreRevsFile .git-blame-ignore-revs
     fi
-    if [ ! -L ".git/hooks/pre-commit" ]; then
+
+    # git-path hooks resolves to the *common* hooks dir, so this installs once
+    # for the primary checkout and every worktree that shares it.
+    HOOKS_DIR="$(git rev-parse --git-path hooks)"
+    # Anchor the symlink to the primary checkout, not $ROOT -- in a worktree
+    # $ROOT is the worktree itself, and the hooks dir is shared, so pointing
+    # at $ROOT would leave a dangling symlink once that worktree is removed.
+    PRIMARY_ROOT="$(cd "$(dirname -- "$(git rev-parse --git-common-dir)")" && pwd)"
+    if [ ! -e "${HOOKS_DIR}/pre-commit" ]; then
         echo ""
         echo "Installing pre-commit hook"
-        ln -s "$ROOT/.git_hooks_pre-commit" ".git/hooks/pre-commit"
+        ln -sf "${PRIMARY_ROOT}/.git_hooks_pre-commit" "${HOOKS_DIR}/pre-commit"
     fi
 fi
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-echo "## bootstrap ###################################################################"
-script/bootstrap
+set -e
 
 # Get current script path
 SCRIPT_PATH="$( dirname -- "$( readlink -f -- "${0}"; )"; )"
+
+echo "## bootstrap ###################################################################"
+"${SCRIPT_PATH}/bootstrap"
+
 # Activate OctoDNS Python venv
 source "${SCRIPT_PATH}/common.sh"
 
@@ -19,9 +22,9 @@ rm -f *.pyc
 echo "## begin #######################################################################"
 # For now it's just lint...
 echo "## lint ########################################################################"
-script/lint
+"${SCRIPT_PATH}/lint"
 echo "## formatting ##################################################################"
-script/format --check || (echo "Formatting check failed, run ./script/format" && exit 1)
+"${SCRIPT_PATH}/format" --check || (echo "Formatting check failed, run ./script/format" && exit 1)
 echo "## tests/coverage ##############################################################"
-script/coverage
+"${SCRIPT_PATH}/coverage"
 echo "## complete ####################################################################"


### PR DESCRIPTION
## Summary
- `.git_hooks_pre-commit` resolved the hook's `$0` symlink back to the primary checkout via `readlink -f`, so committing from a linked `git worktree` ran lint/format/coverage against the wrong tree (the primary's, not the worktree being committed). Now uses `git rev-parse --show-toplevel` to find the correct tree.
- `script/bootstrap`'s git-setup block guarded on `[ -d ".git" ]`, which is false in a worktree (`.git` is a file there), silently skipping blame config and hook install. Now guards with `git rev-parse --git-dir`, installs into the *common* hooks dir via `git rev-parse --git-path hooks` (shared across all worktrees), and anchors the hook symlink to the primary checkout rather than `$ROOT` so it can't dangle once a worktree is removed.
- `script/cibuild` had no `set -e` of its own, so a failing `script/bootstrap` at the top wasn't fatal. Added `set -e` and switched to absolute script invocations.

This is a straight port of [octodns/octodns#1451](https://github.com/octodns/octodns/pull/1451), which made the same fix in the core repo, and [octodns/octodns-hetzner#70](https://github.com/octodns/octodns-hetzner/pull/70), the pilot that validated this rollout.

/cc octodns/octodns#1451 source of this fix

## Test plan
- [x] Pre-commit hook ran lint/format/coverage/changelog-check locally when the fix commit was made
- [x] Diff for `.git_hooks_pre-commit` and `script/bootstrap` verified byte-for-byte identical to core's fix
- [x] `script/cibuild` diff matches the same shape, with the module-specific `find` line left untouched